### PR TITLE
Add margin to sections following main section in careers single page

### DIFF
--- a/assets/scss/careers/single.scss
+++ b/assets/scss/careers/single.scss
@@ -31,6 +31,12 @@
   font-size: 0.75rem;
 }
 
+main section + section {
+  // This is a deviation from global styles
+  // assets/scss/layout.scss line 41
+  margin-top: 1rem;
+}
+
 @media screen and (min-width: 769px) {
   .career-heading {
     .career-title {


### PR DESCRIPTION
This change is ONLY to the single career listing pages. There is a global style for the margin-top but this change overrides and changes the value from 3rem to 1rem between sections for ONLY the single career listing pages.

@alexrekas If you want to make this change global we can.