### PR TITLE
update work-items to not display drafts

### DIFF
--- a/content/work/workradar.md
+++ b/content/work/workradar.md
@@ -5,6 +5,7 @@ summary: "A modern tool to help companies safely return to the workplace during 
 title: "WorkRadar"
 weight: 3
 featured_image: "workradar-logo.png"
+draft: true
 ---
 
 The pandemic changed the world of work forever. Many businesses that could allow their employees to work remotely did. Many who made the abrupt shift to working from home may never need to return to the office again. Other essential businesses apart from healthcare facilities such as pharmacies, supermarkets, manufacturing, banks, schools and transportation hubs required their employees, students and customers to enter the workplace. COVID-19 was spreading. Testing was slow causing public contact tracing to be ineffective. Guidance from Federal, CDC and state level confusing. Decision making was being pushed down to individual businesses and their customers. Business leaders are having to make decisions that could dramatically affect the health and well-being of their employees. Now with a vaccine on the horizon and more businesses looking to gradually allow their employees safely to the workplace a solution is needed.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -93,7 +93,7 @@
   <section class="recent-work-section">
     <h2 class="work-section-heading">Our Work</h2>
     <ul class="work-list">
-      {{ range first 4 (where .Site.RegularPages "Section" "work") }}
+      {{ range first 4 (where (where .Site.RegularPages "Section" "work") "Draft" "!=" true) }}
         {{ partial
           "work-item" .
         }}

--- a/layouts/work/list.html
+++ b/layouts/work/list.html
@@ -15,7 +15,7 @@
     <h1>Our Work</h1>
     {{ .Content }}
     <ul class="work-list">
-      {{ range .Pages }}{{ partial "work-item" . }}{{ end }}
+      {{ range where .Pages "Draft" "!=" true }}{{ partial "work-item" . }}{{ end }}
     </ul>
   </section>
 {{ end }}


### PR DESCRIPTION
This will remove the item "Workradar" because Workradar is put into draft mode. This will save the content but not display it. Also gives the ability to not display any work-item that is tagged as Draft.